### PR TITLE
reference uberjar with an absolute path

### DIFF
--- a/src/leiningen/uberimage.clj
+++ b/src/leiningen/uberimage.clj
@@ -18,7 +18,7 @@
   [{:keys [base-image]}]
   (format "FROM %s
 ADD uberjar.jar uberjar.jar
-CMD [\"/usr/bin/java\", \"-jar\", \"uberjar.jar\"]"
+CMD [\"/usr/bin/java\", \"-jar\", \"/uberjar.jar\"]"
           base-image))
 
 (defn buildtar


### PR DESCRIPTION
so container working directory can be set elsewhere than /

this permits lein-uberimage generated images to be used with deimos, the mesos
docker containerizer, which sets a temporary working directory
