### PR TITLE
Include additional instructions in Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ image's `CMD` and to place extra files into the image.
 
 ```clj
 :uberimage {:cmd ["/bin/dash" "/myrunscript" "param1" "param2"]
+            :instructions ["RUN apt-get update && apt-get -y dist-upgrade"]
             :files {"myrunscript" "docker/myrunscript"}
             :tag "user/repo:tag"}
 ```
 
 The `:cmd` value maps directly to a Dockerfile CMD statement
+
+The `:instructions` value specifies a list of Dockerfile instructions
+to be inserted into the generated Dockerfile immediately after
+the `FROM` instruction at the start of the Dockerfile
 
 The `:files` value is a map of additional files to be copied into the
 docker image. Keys are docker image target paths and values are lein

--- a/src/leiningen/uberimage.clj
+++ b/src/leiningen/uberimage.clj
@@ -15,16 +15,18 @@
 
 (defn dockerfile
   "Return a dockerfile string"
-  [{:keys [cmd files base-image]}]
+  [{:keys [cmd files base-image instructions]}]
   (let [cmd (or cmd ["/usr/bin/java" "-jar" "/uberjar.jar"])
         cmd (if (sequential? cmd) cmd [cmd])
         cmd-str (->> (for [s cmd] (str "\"" s "\""))
                      (string/join ","))]
-    (->> (concat [(str "FROM " base-image)
-                  "ADD uberjar.jar uberjar.jar"
+    (->> (concat [(str "FROM " base-image)]
+                 instructions
+                 ["ADD uberjar.jar uberjar.jar"
                   (str "CMD [" cmd-str "]")]
                  (for [[tar-path local-path] files]
                    (str "ADD " tar-path " " tar-path)))
+         (filter identity)
          (string/join "\n"))))
 
 (defn buildtar


### PR DESCRIPTION
Allows the insertion of additional Dockerfile instructions

The :instructions value is taken from the :uberimage options map
in project.clj and specifies a list of Dockerfile instructions to
be inserted immediately after the FROM instruction at the start
of the Dockerfile.

Motivation was the shellshock vulnerability : I needed a way to 
do a dist-upgrade on the base-image and not to have to wait
for upstream base-images to be updated.
