### PR TITLE
Allow the use of the Leiningen project version as the image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ docker image. Keys are docker image target paths and values are lein
 project source paths.
 
 The `:tag` value supplies a repository name (and optionally a tag) to
-be applied to the resulting image in case of success.
+be applied to the resulting image in case of success. If `:project-version-tag`
+is set to `true`, the Leiningen project version is used as the tag.
+In this case, the `:tag` value refers only to the repository name.
 
 The `:base-image` value is used to specify the base image from which
 the project image is built (defaults to `pallet/java`).
@@ -92,6 +94,13 @@ resulting image in case of success can be specified using `-t`.
 
 ```
 lein uberimage -t user/repo:tag
+```
+
+The Leiningen project version can be used as the image tag
+via the `-p` option.
+
+```
+lein uberimage -t user/repo -p
 ```
 
 ## Limitations

--- a/src/leiningen/uberimage.clj
+++ b/src/leiningen/uberimage.clj
@@ -98,6 +98,9 @@
       (str "Repository name (and optionally a tag) to be applied to the "
            "resulting image in case of success")
       :validate [string? "Must be a string"]]
+     ["-p" "--project-version-tag"
+      (str "Use the Leiningen project version as the image tag. "
+           "The repository name is then specified with -t.")]
      ["-T" "--tlsverify TLSVERIFY"
       "Use TLS and verify the remote"
       :default (:verify env-endpoint)]
@@ -199,7 +202,9 @@
                 :trust-store ts-path
                 :trust-store-pass ks-pw}
             req (filter-api-params {:body piped-input-stream
-                                    :t (:tag options)})
+                                    :t (if (:project-version-tag options)
+                                         (str (:tag options) ":" (:version project))
+                                         (:tag options))})
             resp (try
                    (build ep req)
                    (catch java.net.ConnectException e


### PR DESCRIPTION
This PR adds a `:project-version-tag` option that allows the Leiningen project version to be used as the image tag. The `:tag` option would then only refer to the repository.

A cleaner way would be to have separate `:repository` and `:tag` options..
